### PR TITLE
doc(sentry): sentry 슬라이드 링크 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 ## Sentry
 - [마크다운](tech/sentry.md) 
-- [슬라이드](tech/sentry/index.html)
+- [슬라이드](https://harry-shopl.github.io/md-slides/tech/sentry/)


### PR DESCRIPTION
Github에서 제공하는 Pages 기능을 이용하여
생성된 슬라이드 사이트를 웹상에서 볼 수 있도록 설정 후
해당 URL의 링크로 변경